### PR TITLE
added stroke width option. defaults to 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Typically, you'll use widgets like `Text`, `RichText`, `TextField`, or `TextForm
 #### AnimatedLineThrough
 
 The `AnimatedLineThrough` widget is ready to use out-of-the-box, just like any other declarative
-widget. It expects two arguments: `duration` and `isCrossed`.
+widget. It expects 3 arguments: `duration`, `isCrossed` and `strokeWidth`(optional). 
 
 Here's an example using `Text` as the child widget:
 
@@ -27,12 +27,14 @@ Here's an example using `Text` as the child widget:
 AnimatedLineThrough(
   duration: const Duration(milliseconds: 500),
   isCrossed: _isCrossed,
+  strokeWidth: 2,
   child: Text('Our text'),
 );
 ```
 
-`duration` specifies the duration of the animation, while `isCrossed` is a boolean that indicates
-whether the text should have a line through effect or not.
+- `duration` specifies the duration of the animation,
+- `isCrossed` is a boolean that indicates whether the text should have a line through effect or not,
+- `strokeWidth` defines the width of the line-through to paint over the text.
 
 #### AnimatedLineThroughRaw
 
@@ -53,6 +55,7 @@ late final _animation = Tween(begin: 0.0, end: 1.0).animate(
 AnimatedLineThroughRaw(
   crossed: _animation,
   color: Colors.black,
+  strokeWidth: 2.5,
   child: Text('Our text'),
 );
 ```

--- a/lib/src/animated_line_through.dart
+++ b/lib/src/animated_line_through.dart
@@ -55,6 +55,11 @@ class AnimatedLineThrough extends StatefulWidget {
   /// Defaults to null. In this case use [duration].
   final Duration? reverseDuration;
 
+  /// The width of the stroke to paint over the text
+  ///
+  /// If this is not provided, default value of 1.5 will be used.
+  final double? strokeWidth;
+
   /// Creates a animated line through.
   ///
   /// @{macro line_child}
@@ -66,6 +71,7 @@ class AnimatedLineThrough extends StatefulWidget {
     required this.isCrossed,
     required this.duration,
     this.color,
+    this.strokeWidth,
     this.curve = Curves.linear,
     this.reverseCurve,
     this.reverseDuration,
@@ -114,10 +120,12 @@ class _AnimatedLineThroughState extends State<AnimatedLineThrough>
     final Color color = widget.color ??
         DefaultTextStyle.of(context).style.color ??
         Theme.of(context).colorScheme.onSurface;
+    final double strokeWidth = widget.strokeWidth ?? 1.5;
 
     return AnimatedLineThroughRaw(
       crossed: _animation,
       color: color,
+      rawStrokeWidth: strokeWidth,
       child: widget.child,
     );
   }
@@ -142,6 +150,11 @@ class AnimatedLineThroughRaw extends SingleChildRenderObjectWidget {
   /// The color of cross-line itself.
   final Color color;
 
+  /// The width of the stroke to paint over the text
+  ///
+  /// If this is not provided, default value of 1.5 will be used.d
+  final double? rawStrokeWidth;
+
   /// Creates a raw animated line through.
   ///
   /// @{macro line_child}
@@ -149,15 +162,19 @@ class AnimatedLineThroughRaw extends SingleChildRenderObjectWidget {
     super.key,
     required this.crossed,
     required this.color,
+    this.rawStrokeWidth,
     super.child,
   }) : assert(child != null);
 
   @override
   RenderObject createRenderObject(BuildContext context) {
     final isAroundTextField = child is TextField || child is TextFormField;
+    final double strokeWidth = rawStrokeWidth ?? 1.5;
+
     return _AnimatedLineThroughRenderObject(
       crossed: crossed,
       color: color,
+      strokeWidth: strokeWidth,
       isAroundTextField: isAroundTextField,
     );
   }
@@ -195,9 +212,14 @@ class _AnimatedLineThroughRenderObject extends RenderProxyBox {
   /// Many hacks and possible bugs, but.. well.. ok. :)
   final bool isAroundTextField;
 
+  /// The width of the stroke to paint over the text
+  ///
+  /// If this is not provided, default value of 1.5 will be used.
+  final double strokeWidth;
+
   /// Main paint object.
   /// Cache it here.
-  late final Paint _paint = Paint()..strokeWidth = 1.5;
+  late final Paint _paint = Paint();
 
   /// Metrics of the child's text.
   ///
@@ -222,6 +244,7 @@ class _AnimatedLineThroughRenderObject extends RenderProxyBox {
     required this.crossed,
     required this.color,
     required this.isAroundTextField,
+    required this.strokeWidth,
     RenderBox? child,
   }) : super(child) {
     crossed.addListener(_onCrossedChanged);
@@ -248,6 +271,7 @@ class _AnimatedLineThroughRenderObject extends RenderProxyBox {
       }
 
       _paint.color = color;
+      _paint.strokeWidth = strokeWidth;
 
       double currentWidth = _fullTextWidth * crossed.value;
       double currentHeight = offset.dy;

--- a/lib/src/animated_line_through.dart
+++ b/lib/src/animated_line_through.dart
@@ -58,7 +58,7 @@ class AnimatedLineThrough extends StatefulWidget {
   /// The width of the stroke to paint over the text
   ///
   /// If this is not provided, default value of 1.5 will be used.
-  final double? strokeWidth;
+  final double strokeWidth;
 
   /// Creates a animated line through.
   ///
@@ -71,7 +71,7 @@ class AnimatedLineThrough extends StatefulWidget {
     required this.isCrossed,
     required this.duration,
     this.color,
-    this.strokeWidth,
+    this.strokeWidth = 1.5,
     this.curve = Curves.linear,
     this.reverseCurve,
     this.reverseDuration,
@@ -120,12 +120,11 @@ class _AnimatedLineThroughState extends State<AnimatedLineThrough>
     final Color color = widget.color ??
         DefaultTextStyle.of(context).style.color ??
         Theme.of(context).colorScheme.onSurface;
-    final double strokeWidth = widget.strokeWidth ?? 1.5;
 
     return AnimatedLineThroughRaw(
       crossed: _animation,
       color: color,
-      rawStrokeWidth: strokeWidth,
+      strokeWidth: widget.strokeWidth,
       child: widget.child,
     );
   }
@@ -153,7 +152,7 @@ class AnimatedLineThroughRaw extends SingleChildRenderObjectWidget {
   /// The width of the stroke to paint over the text
   ///
   /// If this is not provided, default value of 1.5 will be used.d
-  final double? rawStrokeWidth;
+  final double strokeWidth;
 
   /// Creates a raw animated line through.
   ///
@@ -162,14 +161,13 @@ class AnimatedLineThroughRaw extends SingleChildRenderObjectWidget {
     super.key,
     required this.crossed,
     required this.color,
-    this.rawStrokeWidth,
+    this.strokeWidth = 1.5,
     super.child,
   }) : assert(child != null);
 
   @override
   RenderObject createRenderObject(BuildContext context) {
     final isAroundTextField = child is TextField || child is TextFormField;
-    final double strokeWidth = rawStrokeWidth ?? 1.5;
 
     return _AnimatedLineThroughRenderObject(
       crossed: crossed,
@@ -187,6 +185,7 @@ class AnimatedLineThroughRaw extends SingleChildRenderObjectWidget {
   ) {
     super.updateRenderObject(context, renderObject);
     renderObject.color = color;
+    renderObject.strokeWidth = strokeWidth;
   }
 }
 
@@ -215,7 +214,7 @@ class _AnimatedLineThroughRenderObject extends RenderProxyBox {
   /// The width of the stroke to paint over the text
   ///
   /// If this is not provided, default value of 1.5 will be used.
-  final double strokeWidth;
+  double strokeWidth;
 
   /// Main paint object.
   /// Cache it here.


### PR DESCRIPTION
This PR adds a new option called strokeWidth to both AnimatedLineThrough and AnimatedLineThroughRaw widget as optional parameters which tell the paint to use a custom stroke width value instead of a hard-coded value as 1.5.